### PR TITLE
Fix carga accumulation in updateSummary

### DIFF
--- a/index.html
+++ b/index.html
@@ -1857,7 +1857,8 @@
       for(const p of pts){
         if(last){ distKm += haversine(last.lat,last.lng,p.lat,p.lng); }
         min += stopTimeFor(p.tipo);
-        carga += (p.monto||0 < 0 ? 0 : (p.monto||0)); // solo sumo abastecimientos como descarga del camión? ajustable
+        const monto = Number(p.monto) || 0;
+        carga += monto < 0 ? 0 : monto; // solo sumo abastecimientos como descarga del camión? ajustable
         maxMonto = Math.max(maxMonto, carga);
         last = p;
       }


### PR DESCRIPTION
## Summary
- ensure the carga accumulation in updateSummary evaluates the monto before applying a fallback
- keep negative amounts from contributing to the peak transported load metric

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cf2489e3e08331a3ee45e96b7e9bee