### PR TITLE
Update route sources when toggling orders

### DIFF
--- a/index.html
+++ b/index.html
@@ -1645,7 +1645,12 @@
       [...tbody.querySelectorAll('input[data-act="usar"]')].forEach(inp=>{
         inp.addEventListener('change', (ev)=>{
           const id = ev.target.closest('tr').dataset.id;
-          const o = State.ord.find(x=>x.id===id); if(o){ o.usar = !!ev.target.checked; save(DB.ord, State.ord); }
+          const o = State.ord.find(x=>x.id===id);
+          if(o){
+            o.usar = !!ev.target.checked;
+            save(DB.ord, State.ord);
+            Route?.refreshSources?.();
+          }
         });
       });
       [...tbody.querySelectorAll('button[data-act="edit"]')].forEach(btn=>{
@@ -2012,6 +2017,9 @@
         addPointToRoute(src, b.closest('tr').querySelector('input[data-act="prio"]')?.checked);
       }));
       renderIgnoredPoints();
+    }
+    function refreshSources(){
+      renderPts();
     }
     ptsQ?.addEventListener('input', renderPts);
     document.getElementById('addFromOrdenes')?.addEventListener('click', ()=>{
@@ -2536,6 +2544,7 @@
 
     // Init
     renderPts(); draw();
+    return { renderPts, refreshSources };
   })();
 
   /* =====================================================================


### PR DESCRIPTION
## Summary
- add a refreshSources helper to the Route module that reuses renderPts and expose both functions publicly
- call the new Route.refreshSources method after toggling an order's "usar" checkbox to immediately refresh the points list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf3e15dc288331b26ea0424ce95704