### PR TITLE
Agregar confirmación al limpiar ruta

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@
 - [ ] Restaurar un valor de **Max. monto por camión** suficiente para la ruta y confirmar que la optimización finaliza correctamente y que la alerta visual desaparece.
 - [ ] Dejar la cabecera sin seleccionar, agregar varios puntos a la ruta y verificar que el resumen muestra guiones en tiempo/monto mientras se muestra un aviso pidiendo elegir cabecera; los botones **Optimizar** y **Exportar** deben permanecer deshabilitados.
 - [ ] Importar un CSV de órdenes con algunas filas marcadas como **usar** pero sin coordenadas. Al cargarlo debe mostrarse un aviso y las órdenes sin lat/lng no deben aparecer en la lista ni agregarse a la ruta.
+- [ ] En la vista de rutas, cargar varias paradas y presionar **Limpiar**. Cancelar el diálogo de confirmación debe mantener intacta la lista de paradas actual.

--- a/index.html
+++ b/index.html
@@ -2111,7 +2111,12 @@
     document.getElementById('btnDeshacer')?.addEventListener('click', ()=>{
       const prev = undoStack.pop(); if(prev){ currentRoute = cloneRoutes(prev); draw(); }
     });
-    document.getElementById('btnLimpiarRuta')?.addEventListener('click', ()=>{ undoStack.push(cloneRoutes()); currentRoute = [[]]; draw(); });
+    document.getElementById('btnLimpiarRuta')?.addEventListener('click', ()=>{
+      if(!confirm('¿Eliminar todas las paradas?')) return;
+      undoStack.push(cloneRoutes());
+      currentRoute = [[]];
+      draw();
+    });
 
     function stopTimeFor(tipo){
       if(/^suc/i.test(tipo||'')) return cfg.stopSuc||5;


### PR DESCRIPTION
## Summary
- solicitar confirmación al usuario antes de limpiar por completo la ruta actual
- evitar que se registren cambios si el usuario cancela la acción
- documentar una prueba manual que verifica que cancelar mantiene la ruta

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf4939b4d083319052ee77ad019241