### PR TITLE
Validate route approval requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -2587,13 +2587,24 @@
       }
     });
     document.getElementById('btnAprobar')?.addEventListener('click', ()=>{
+      const origenCodigo = (selOrigen?.value || '').trim();
+      const hasRoute = Array.isArray(currentRoute) && currentRoute.length > 0
+        && currentRoute.some(route => Array.isArray(route) && route.length > 0);
+      if(!hasRoute || !origenCodigo){
+        showToast('Seleccioná una cabecera y asegurate de que la ruta tenga paradas antes de aprobar.');
+        return;
+      }
       const nombre = prompt('Nombre de la ruta para historial:', 'Ruta '+ new Date().toLocaleString('es-AR'));
       if(!nombre) return;
-      const origen = State.cab.find(c=>c.codigo===selOrigen.value);
-      const rutas = cloneRoutes();
+      const origen = State.cab.find(c=>c.codigo===origenCodigo);
+      if(!origen){
+        showToast('Cabecera inválida. Revisá la selección antes de aprobar.');
+        return;
+      }
+      const rutas = cloneRoutes().filter(route => Array.isArray(route) && route.length > 0);
       const rec = {
         id: uuid(), fecha: new Date().toISOString().slice(0,10), nombre,
-        origen: selOrigen.value,
+        origen: origenCodigo,
         rutas,
         puntos: flattenRoutes(rutas).map(p => ({...p})),
         camiones: parseInt(nCamionesInput?.value, 10)||1,


### PR DESCRIPTION
## Summary
- block route approval when no origin is selected or there are no assigned stops
- ensure only complete, non-empty routes are stored in the history records
- add safeguards against approving routes with an invalid origin selection

## Testing
- not run (web project without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cf49d8c9f883319d7ad96fcbc2529b